### PR TITLE
Add lock screen requiring age code

### DIFF
--- a/index.html
+++ b/index.html
@@ -17,6 +17,27 @@
 
 <body>
 
+    <div id="lockScreen" class="lock-screen">
+      <div class="lock-box">
+        <p>Enter the special number 💖</p>
+        <input id="lockInput" type="password" maxlength="2" readonly />
+        <div class="numpad">
+          <button class="number" data-num="1">1</button>
+          <button class="number" data-num="2">2</button>
+          <button class="number" data-num="3">3</button>
+          <button class="number" data-num="4">4</button>
+          <button class="number" data-num="5">5</button>
+          <button class="number" data-num="6">6</button>
+          <button class="number" data-num="7">7</button>
+          <button class="number" data-num="8">8</button>
+          <button class="number" data-num="9">9</button>
+          <button id="clearBtn">Clear</button>
+          <button class="number" data-num="0">0</button>
+          <button id="enterBtn">Enter</button>
+        </div>
+      </div>
+    </div>
+
     <audio class="song" loop autoplay>
         <source src="./music/hbd.mpeg" type="audio/mpeg">
         </source>

--- a/script/main.js
+++ b/script/main.js
@@ -1,20 +1,45 @@
-// trigger to play music in the background with sweetalert
-window.addEventListener('load', () => {
+// trigger to play music in the background with sweetalert after unlocking
+const startCelebration = () => {
     Swal.fire({
         title: 'เปิดเพลงด้วยมั้ยยย',
         icon: 'question',
-        
+
         confirmButtonColor: '#3085d6',
         cancelButtonColor: '#d33',
         confirmButtonText: 'เปิดอย่างเดียวไม่ให้เลือกกก😊😊',
         cancelButtonText: 'No',
-        
+
     }).then((result) => {
         if (result.isConfirmed) {
             document.querySelector('.song').play();
             animationTimeline();
         } else {
             animationTimeline();
+        }
+    });
+};
+
+window.addEventListener('load', () => {
+    const input = document.getElementById('lockInput');
+    const lockScreen = document.getElementById('lockScreen');
+
+    document.querySelectorAll('.numpad .number').forEach(btn => {
+        btn.addEventListener('click', () => {
+            input.value += btn.dataset.num;
+        });
+    });
+
+    document.getElementById('clearBtn').addEventListener('click', () => {
+        input.value = '';
+    });
+
+    document.getElementById('enterBtn').addEventListener('click', () => {
+        if (input.value === '21') {
+            lockScreen.style.display = 'none';
+            startCelebration();
+        } else {
+            input.value = '';
+            Swal.fire('ลองใหม่น้าา');
         }
     });
 });

--- a/style/main.css
+++ b/style/main.css
@@ -290,3 +290,58 @@ body {
     font-weight: lighter;
   }
 }
+
+.lock-screen {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100vw;
+  height: 100vh;
+  background: rgba(0,0,0,0.8);
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  z-index: 9999;
+}
+
+.lock-box {
+  background: #fff;
+  padding: 20px;
+  border-radius: 10px;
+  text-align: center;
+}
+
+.lock-box input {
+  width: 180px;
+  height: 40px;
+  font-size: 1.2rem;
+  text-align: center;
+  margin-bottom: 10px;
+}
+
+.numpad {
+  display: grid;
+  grid-template-columns: repeat(3, 60px);
+  gap: 10px;
+  justify-content: center;
+}
+
+.numpad button {
+  width: 60px;
+  height: 60px;
+  font-size: 1.2rem;
+  border: none;
+  border-radius: 10px;
+  background: #ffd6e8;
+  cursor: pointer;
+}
+
+.numpad button:active {
+  background: #ff9ecf;
+}
+
+#clearBtn, #enterBtn {
+  grid-column: span 3;
+  background: #ff9ecf;
+  color: #fff;
+}


### PR DESCRIPTION
## Summary
- add overlay lock screen with cute numpad for entering special age code
- style new lock screen and numpad
- start celebration only after correct code entry

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6895847f4cd083318b2add17dd978203